### PR TITLE
Be consistent with identifier naming

### DIFF
--- a/src/Core/User.cs
+++ b/src/Core/User.cs
@@ -5,7 +5,7 @@ namespace Core;
 public class User
 {
     [IsProjected(true)]
-    public required string Id { get; init; }
+    public required string UserId { get; init; }
     public required string Username { get; init; }
     public required string Name { get; init; }
     public Uri? Picture { get; set; }

--- a/src/Mutations/UserMutation.cs
+++ b/src/Mutations/UserMutation.cs
@@ -18,13 +18,13 @@ public class UserMutation
         var ownerId = principal.FindFirst(ClaimTypes.NameIdentifier)!.Value;
         var owner = await context
             .Users
-            .Where(user => user.Id == ownerId)
+            .Where(user => user.UserId == ownerId)
             .Include(user => user.Following)
             .FirstAsync();
 
         var target = await context
             .Users
-            .Where(user => user.Id == userId)
+            .Where(user => user.UserId == userId)
             .FirstOrDefaultAsync();
 
         if (target is null)
@@ -47,13 +47,13 @@ public class UserMutation
         var ownerId = principal.FindFirst(ClaimTypes.NameIdentifier)!.Value;
         var owner = await context
             .Users
-            .Where(user => user.Id == ownerId)
+            .Where(user => user.UserId == ownerId)
             .Include(user => user.Following)
             .FirstAsync();
 
         var target = await context
             .Users
-            .Where(user => user.Id == userId)
+            .Where(user => user.UserId == userId)
             .FirstOrDefaultAsync();
 
         if (target is null)

--- a/src/Queries/ActivityQuery.cs
+++ b/src/Queries/ActivityQuery.cs
@@ -85,6 +85,6 @@ public class ActivityQuery
         return context
             .Users
             .AsNoTracking()
-            .Where(user => user.Id == parent.UserId);
+            .Where(user => user.UserId == parent.UserId);
     }
 }

--- a/src/Queries/Query.cs
+++ b/src/Queries/Query.cs
@@ -28,6 +28,6 @@ public class Query
         return context
             .Users
             .AsNoTracking()
-            .Where(user => user.Id == userId);
+            .Where(user => user.UserId == userId);
     }
 }

--- a/src/Queries/UserQuery.cs
+++ b/src/Queries/UserQuery.cs
@@ -18,7 +18,7 @@ public class UserQuery
         return context
             .Activities
             .AsNoTracking()
-            .Where(activity => activity.UserId == parent.Id)
+            .Where(activity => activity.UserId == parent.UserId)
             .OrderByDescending(activity => activity.StartTime);
     }
 
@@ -32,7 +32,7 @@ public class UserQuery
         return context
             .Activities
             .AsNoTracking()
-            .Where(activity => activity.UserId == parent.Id)
+            .Where(activity => activity.UserId == parent.UserId)
             .Where(activity => activity.ActivityId == activityId);
     }
 
@@ -45,7 +45,7 @@ public class UserQuery
         return context
             .Users
             .AsNoTracking()
-            .Where(user => user.Id == parent.Id)
+            .Where(user => user.UserId == parent.UserId)
             .SelectMany(user => user.Following);
     }
 
@@ -58,7 +58,7 @@ public class UserQuery
         return context
             .Users
             .AsNoTracking()
-            .Where(user => user.Id == parent.Id)
+            .Where(user => user.UserId == parent.UserId)
             .SelectMany(user => user.Followers);
     }
 
@@ -71,7 +71,7 @@ public class UserQuery
         var user = context
             .Users
             .AsNoTracking()
-            .Where(user => user.Id == parent.Id);
+            .Where(user => user.UserId == parent.UserId);
 
         var activities = user
             .SelectMany(user => user.Activities);

--- a/src/Server/Configuration/CustomJwtBearerEvents.cs
+++ b/src/Server/Configuration/CustomJwtBearerEvents.cs
@@ -48,7 +48,7 @@ public static class CustomJwtBearerEvents
             .CreateDbContextAsync();
 
 
-        if (await context.Users.SingleOrDefaultAsync(user => user.Id == token.Subject) is { } user)
+        if (await context.Users.SingleOrDefaultAsync(user => user.UserId == token.Subject) is { } user)
         {
             user.Picture = new Uri(userInfo.Claims.Single(claim => claim.Type is JwtClaimTypes.Picture).Value);
         }
@@ -56,7 +56,7 @@ public static class CustomJwtBearerEvents
         {
             user = new User
             {
-                Id = userInfo.Claims.Single(claim => claim.Type is JwtClaimTypes.Subject).Value,
+                UserId = userInfo.Claims.Single(claim => claim.Type is JwtClaimTypes.Subject).Value,
                 Name = userInfo.Claims.Single(claim => claim.Type is JwtClaimTypes.Name).Value,
                 Username = userInfo.Claims.Single(claim => claim.Type is JwtClaimTypes.PreferredUserName).Value,
                 Picture = userInfo.Claims


### PR DESCRIPTION
Ensures that the naming of fields in the resulting API schema is consistent.