### PR TITLE
Include root certificates in Docker image

### DIFF
--- a/backend/default.nix
+++ b/backend/default.nix
@@ -30,6 +30,8 @@ in
 
       extraCommands = "mkdir -m 0777 tmp";
 
+      contents = [ pkgs.cacert ];
+
       config = {
         WorkingDir = "/data";
         Cmd = [ (lib.getExe backend) ];


### PR DESCRIPTION
Fixes an error occuring where outgoing HTTPS requests failed due to certificate validation errors. Caused by missing root certificates.